### PR TITLE
[fix] 注文機能 #58

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -16,7 +16,7 @@ class Public::OrdersController < ApplicationController
       @order.name        = current_customer.last_name + current_customer.first_name
 
     elsif params[:order][:addresses] == "addresses"
-      addresses = Addresses.find(params[:order][:address_id])
+      addresses = Address.find(params[:order][:address_index])
       @order.postal_code = addresses.postal_code
       @order.address     = addresses.address
       @order.name        = addresses.name

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -16,7 +16,7 @@ class Public::OrdersController < ApplicationController
       @order.name        = current_customer.last_name + current_customer.first_name
 
     elsif params[:order][:addresses] == "addresses"
-      addresses = Address.find(params[:order][:address_index])
+      addresses = Address.find(params[:order][:addresses_id])
       @order.postal_code = addresses.postal_code
       @order.address     = addresses.address
       @order.name        = addresses.name

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -9,20 +9,4 @@ class Order < ApplicationRecord
   validates :postal_code, presence: true, length: {is: 7}, numericality: { only_integer: true }
   validates :shipping_fee, :payment_amount, numericality: { only_integer: true }
 
-  def tax_price
-    (self.price * 1.10).round
-  end
-
-  def sub_prise
-    (self.price * 1.10) * self.order_item.number
-  end
-
-  def total_price
-    array = []
-    self.order_items.each do |order_item|
-       array << order_item.price * order_item.number
-   end
-    array.sum
-  end
-
 end

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -15,7 +15,6 @@
           <%= form_with model: @cart_item, local: true do |f| %>
             <%= f.hidden_field :item_id, :value => @item.id %>
             <%= f.select :number, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], {include_blank: '個数選択'}, class: "mb-3" %>
-            <p class="text-danger text-center"><%= flash[:danger] %></p>
             <%= f.submit 'カートに入れる', class: 'btn btn-success btn-block w-35' %>
           <% end %>
         <% else %>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -15,6 +15,7 @@
           <%= form_with model: @cart_item, local: true do |f| %>
             <%= f.hidden_field :item_id, :value => @item.id %>
             <%= f.select :number, [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20], {include_blank: '個数選択'}, class: "mb-3" %>
+            <p class="text-danger text-center"><%= flash[:danger] %></p>
             <%= f.submit 'カートに入れる', class: 'btn btn-success btn-block w-35' %>
           <% end %>
         <% else %>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -25,7 +25,7 @@
         <div class="col-xs-10 radio ml-3">
           <%= f.radio_button :addresses,  "addresses"%>
           <span>&nbsp登録済住所から選択</span><br>
-          &nbsp&nbsp<%= f.collection_select(:address_index, @addresses, :id, :shipping_address) %>
+          &nbsp&nbsp<%= f.collection_select(:address_id, @addresses, :id, :shipping_address) %>
         </div>
 
         <div class="new-address col-xs-12 radio ml-3">

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -25,7 +25,7 @@
         <div class="col-xs-10 radio ml-3">
           <%= f.radio_button :addresses,  "addresses"%>
           <span>&nbsp登録済住所から選択</span><br>
-          &nbsp&nbsp<%= f.collection_select(:addresses_id, @addresses, :id, :shipping_address) %>
+          &nbsp&nbsp<%= f.collection_select(:address_index, @addresses, :id, :shipping_address) %>
         </div>
 
         <div class="new-address col-xs-12 radio ml-3">

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -25,7 +25,7 @@
         <div class="col-xs-10 radio ml-3">
           <%= f.radio_button :addresses,  "addresses"%>
           <span>&nbsp登録済住所から選択</span><br>
-          &nbsp&nbsp<%= f.collection_select(:address_id, @addresses, :id, :shipping_address) %>
+          &nbsp&nbsp<%= f.collection_select(:addresses_id, @addresses, :id, :shipping_address) %>
         </div>
 
         <div class="new-address col-xs-12 radio ml-3">


### PR DESCRIPTION
## public/orders_controller.rb 記述を修正 
``` public/orders_controller.rb
addresses = Addresses.find(params[:order][:address_id]) # 修正前
addresses = Address.find(params[:order][:addresses_id]) # 修正後
```
## public/orders/new.html.erb 記述を修正
```public/orders/new.html.erb
        <div class="col-xs-10 radio ml-3">
          <%= f.radio_button :addresses,  "addresses"%>
          <span>&nbsp登録済住所から選択</span><br>
          &nbsp&nbsp<%= f.collection_select(:address_id, @addresses, :id, :shipping_address) %> # 修正前
          &nbsp&nbsp<%= f.collection_select(:addresses_id, @addresses, :id, :shipping_address) %> # 修正後
        </div>
```

## models/order.rb 不要な記述を削除
```models/order.rb
  def tax_price
    (self.price * 1.10).round
  end
  def sub_prise
    (self.price * 1.10) * self.order_item.number
  end
  def total_price
    array = []
    self.order_items.each do |order_item|
      array << order_item.price * order_item.number
    end
   array.sum
  end
```