### PR TITLE
[fix] ヘッダーのレイアウト、管理者の注文履歴詳細

### DIFF
--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="row">
-    <div class="col-sm-10 px-sm-0 mx-auto">
-      <h3>注文履歴詳細</h2>
+    <div class="col-sm-10 mx-auto">
+      <h2 class="mt-5 font-weight-bold">注文履歴詳細</h2>
 
       <table class="table table-borderless">
         <tbody>
@@ -42,25 +42,29 @@
       </table>
 
       <div class="d-flex">
-        <table class="table mr-3">
+        <table class="table table-bordered mr-3">
           <thead>
-            <tr class="table-hover table-inverse table-active">
-              <th>商品名</th>
-              <th>単価（税込）</th>
-              <th>数量</th>
-              <th>小計</th>
-              <th>制作ステータス</th>
+            <tr class="table-hover table-inverse table-light">
+              <th class="border-dark">商品名</th>
+              <th class="border-dark">単価（税込）</th>
+              <th class="border-dark">数量</th>
+              <th class="border-dark">小計</th>
+              <th class="border-dark">制作ステータス</th>
             </tr>
           </thead>
 
           <tbody>
+            <% sum = 0 %>
             <% @order_item.each do |order_item| %>
             <tr>
-              <td><%= order_item.item.name %></td>
-              <td><%= (order_item.price).to_s(:delimited) %></td>
-              <td><%= order_item.number %></td>
-              <td><%= (order_item.price * order_item.number).to_s(:delimited) %></td>
-              <td>
+              <td class="border-dark"><%= order_item.item.name %></td>
+              <td class="border-dark"><%= (order_item.tax_price).to_s(:delimited) %></td>
+              <td class="border-dark"><%= order_item.number %></td>
+              <td class="border-dark">
+                <%= (order_item.tax_price * order_item.number).to_s(:delimited) %>
+                <% sum += (order_item.tax_price * order_item.number) %>
+              </td>
+              <td class="border-dark">
                 <%= form_with model: order_item, url: admin_order_order_item_path(order_item), local: true do |f| %>
                   <%= f.select :making_status, OrderItem.making_statuses.keys.map {|k| [k, k]}, {} %>
                   <%= f.submit "更新", class: "btn btn-success btn-sm" %>
@@ -75,7 +79,7 @@
           <tbody>
             <tr>
               <td>商品合計</td>
-              <td><%= (@order.payment_amount).to_s(:delimited) %>円</td>
+              <td><%= sum.to_s(:delimited) %>円</td>
             </tr>
 
             <tr>
@@ -85,7 +89,7 @@
 
             <tr>
               <td>請求金額合計</td>
-              <td><%= (@order.payment_amount + @order.shipping_fee).to_s(:delimited) %>円</td>
+              <td><%= (sum + @order.shipping_fee).to_s(:delimited) %>円</td>
             </tr>
           </tbody>
         </table>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -7,7 +7,7 @@
       </button>
 
       <nav class="mx-auto collapse navbar-collapse justify-content-end", id="navbarSupportedContent">
-        <ul class="navbar-nav mr-auto">
+        <ul class="navbar-nav mx-auto">
           <% if customer_signed_in? %>
             <li  class="nav-text my-3 text-center">
               ようこそ、<%= current_customer.last_name %>さん！


### PR DESCRIPTION
•_header.html.erbでヘッダーのナビゲーションメニューを中央寄せに修正
•admin/orders/show.html.erbで管理者の注文履歴詳細画面の商品合計、請求金額合計の計算を修正