### PR TITLE
[fix]path

### DIFF
--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -51,9 +51,9 @@ class Public::RegistrationsController < Devise::RegistrationsController
   # end
 
   # The path used after sign up.
-  # def after_sign_up_path_for(resource)
-  #   super(resource)
-  # end
+  def after_sign_up_path_for(resource)
+    customers_my_page_path
+  end
 
   # The path used after sign up for inactive accounts.
   # def after_inactive_sign_up_path_for(resource)

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -56,7 +56,7 @@
   </div>
   <div class="row">
     <div class="col-sm-8">
-      <%= link_to "買い物を続ける", items_path, class: "btn btn-primary" %>
+      <%= link_to "買い物を続ける", root_path, class: "btn btn-primary" %>
     </div>
     <div class="col-sm-3 px-sm-0">
       <table class="table table-bordered">


### PR DESCRIPTION
・ショッピングカート画面から買い物を続けるボタンを押したときの遷移先を変更
　items_path → root_path

・サインアップ後の遷移先変更(registrations_controller.rb内のコメントアウトを解除し、pathを記述)
 　root_path(default) → customers_my_page_path