### PR TITLE
[add]顧客：ジャンル検索,[delete]顧客：商品検索

### DIFF
--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,7 +1,7 @@
 class Public::ItemsController < ApplicationController
   def index
-    @items = Item.all.page(params[:page]).per(8).order("created_at DESC")
     @genres = Genre.all
+    @items = Item.all.page(params[:page]).per(8).order("created_at DESC")
   end
 
   def show

--- a/app/controllers/public/searches_controller.rb
+++ b/app/controllers/public/searches_controller.rb
@@ -1,6 +1,23 @@
 class Public::SearchesController < ApplicationController
 
   def search
-    @items = Item.looks(params[:search]).page(params[:page]).per(10)
+    @genres = Genre.all
+    @value = params["search"]["value"]
+    @how = params["search"]["how"]
+    @datas = search_for(@how, @value).page(params[:page]).per(8)
+  end
+
+  private
+
+  def match(value)
+    #.orを使用することで、valueに一致するカラムのデータをnameカラムとgenre_idカラムから探してくる
+    Item.where(name: value).or(Item.where(genre_id: value))
+  end
+
+  def search_for(how, value)
+    case how
+    when 'match'
+      match(value)
+    end
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,21 +1,20 @@
 class Item < ApplicationRecord
-    belongs_to :genre
-    has_many :cart_items, dependent: :destroy
-    has_many :order_items, dependent: :destroy
+  belongs_to :genre
+  has_many :cart_items, dependent: :destroy
+  has_many :order_items, dependent: :destroy
 
-    attachment :image
+  attachment :image
 
-    validates :genre_id, :name, :price, presence: true
-    validates :caption, length: {maximum: 200}
-    validates :price, numericality: { only_integer: true }
+  validates :genre_id, :name, :price, presence: true
+  validates :caption, length: {maximum: 200}
+  validates :price, numericality: { only_integer: true }
 
-    def self.looks(search)
-      return none if search.blank?
-      if search
-        Item.where(['name LIKE ?', "%#{search}%"])
-      else
-        Item.all
-      end
+  def self.looks(search)
+    return none if search.blank?
+    if search
+      Item.where(['name LIKE ?', "%#{search}%"])
+    else
+      Item.all
     end
-
+  end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -24,12 +24,19 @@
             <p class="nav-button btn btn-sm mx-2 my-auto">
               <%= link_to "ログアウト", destroy_customer_session_path, method: :delete, class: "nav-link" %>
             </p>
-            <%= form_with url: search_path, local: true, method: :get do |f| %>
-              <%= f.text_field :search, class: "form-control-sm mt-2", style: "width:100px;", placeholder: "Search" %>
-              <%= f.collection_select(:genre_id, Genre.all, :id, :name, class: "col-sm-8 genre_id") %>
-              <%= f.submit "検索", class: "btn btn-success btn-sm" %>
-            <% end %>
-          <% elsif admin_signed_in? %>
+            <div class="nav-item dropdown mt-2">
+              <div class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                ジャンル検索
+              </div>
+              <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                <% Genre.all.each do |genre| %>
+                <a class="dropdown-item">
+                  <%= link_to genre.name, search_path('search[value]': genre.id, 'search[how]': "match") %>
+                </a>
+                <% end %>
+              </div>
+            </div>
+            <% elsif admin_signed_in? %>
             <p class="nav-button btn btn-sm mx-2 my-auto">
               <%= link_to "商品一覧", admin_items_path, class: "nav-link" %>
             </p>
@@ -63,11 +70,18 @@
             <p class="nav-button btn btn-sm mx-2 my-auto">
               <%= link_to "ログイン", new_customer_session_path, class: "nav-link" %>
             </p>
-            <%= form_with url: search_path, local: true, method: :get do |f| %>
-              <%= f.text_field :search, class: "form-control-sm mt-2", style: "width:100px;", placeholder: "Search" %>
-              <%= f.collection_select(:genre_id, Genre.all, :id, :name, class: "col-sm-8 genre_id") %>
-              <%= f.submit "検索", class: "btn btn-success btn-sm" %>
-            <% end %>
+            <div class="nav-item dropdown mt-2">
+              <div class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                ジャンル検索
+              </div>
+              <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                <% Genre.all.each do |genre| %>
+                <a class="dropdown-item">
+                  <%= link_to genre.name, search_path('search[value]': genre.id, 'search[how]': "match") %>
+                </a>
+                <% end %>
+              </div>
+            </div>
           <% end %>
         </ul>
       </nav>

--- a/app/views/public/searches/search.html.erb
+++ b/app/views/public/searches/search.html.erb
@@ -1,11 +1,36 @@
+<% if @datas.empty? %>
+  <h2 class="text-center pt-5">該当する商品はありません</h2>
+<% else %>
 <div class="container">
   <div class="row">
-    <div class="col-sm-12 px-sm-0">
-      <h2 class="font-weight-bold mt-5 mb-3"><i class="fas fa-birthday-cake"></i>商品一覧（全<%= @items.total_count %>件）</h2>
+    <div class="col-sm-8 px-sm-0">
+      <h2 class="font-weight-bold mt-5 mb-3"><i class="fas fa-search-plus"></i>ジャンル検索一覧</h2>
     </div>
   </div>
-  <%= render 'public/items/new_items', items: @items %>
-  <%= paginate @items %>
+  <div class="row">
+  <div class="d-flex flex-row flex-wrap">
+    <% @datas.each do |data| %>
+    <div class="card-deck mb-5 mr-2", style="width:25%">
+      <div class="card">
+        <div class ="item-image">
+          <%= link_to item_path(data.id) do %>
+            <p class="img card-img-top"><%= attachment_image_tag data, :image, width: "100%", format: "jpeg", fallback: "no_image.jpg" %></p>
+          <% end %>
+        </div>
+        <div class="card-body">
+          <p class="card-title font-weight-bold"><%= data.name %></p>
+          <% if data.is_active == true %>
+            <p class="item-price"><%= ((data.price*1.10).to_i).to_s(:delimited) %>円(税込）</p>
+          <% else %>
+            <p class="text-danger font-weight-bold">Sold out</p>
+          <% end %>
+        </div>
+      </div>
+    </div>
+    <% end %>
+  </div>
 </div>
-
+  <%= paginate @datas %>
+</div>
+<% end %>
 


### PR DESCRIPTION
・顧客側どのページでもジャンル検索ができるように設定。
　search_controller.rb
   ```
    def search
        @genres = Genre.all
        @value = params["search"]["value"]
        @how = params["search"]["how"]
        @datas = search_for(@how, @value).page(params[:page]).per(8)
      end
    
      private
    
      def match(value)
        #.orを使用することで、valueに一致するカラムのデータをnameカラムとgenre_idカラムから探してくる
        Item.where(name: value).or(Item.where(genre_id: value))
      end
    
      def search_for(how, value)
        case how
        when 'match'
          match(value)
        end
      end
```
  _header_controller.rb
```
<div class="nav-item dropdown mt-2">
   <div class="nav-link dropdown-toggle" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
        ジャンル検索
    </div>
    <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
      <% Genre.all.each do |genre| %>
      <a class="dropdown-item">
        <%= link_to genre.name, search_path('search[value]': genre.id, 'search[how]': "match") %>
      </a>
      <% end %>
    </div>
  </div>
```